### PR TITLE
Fix black GitHub action warning

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -3,7 +3,7 @@ name: Check formatting
 on: [push, pull_request]
 
 jobs:
-  lint:
+  black:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The warning was:

> Unexpected input(s) 'black_args', valid inputs are ['entryPoint', 'args']


